### PR TITLE
Fix device mismatch error in predict_ss_values function

### DIFF
--- a/src/eval_utils.py
+++ b/src/eval_utils.py
@@ -79,7 +79,8 @@ def generate_sl_outputs(
         pickle.dump(threshold_dict, f)
 
 def predict_ss_values(X, model):
-    y_preds = torch.sigmoid(model(torch.tensor(X).float()))
+    X_tensor = torch.tensor(X, device=device).float()
+    y_preds = torch.sigmoid(model(X_tensor))
     return y_preds.detach().cpu().numpy()
 
 def generate_ss_outputs(
@@ -111,6 +112,3 @@ def generate_ss_outputs(
 
     with open(os.path.join(model_attrs.outputs_save_path, f"thresholds_ss_mcc.pkl"), "wb") as f:
         pickle.dump(threshold_dict, f)
-
-
-


### PR DESCRIPTION
## Description

This pull request addresses a device mismatch error encountered in the `predict_ss_values` function. The error occurred when tensors involved in the computation were on different devices (cuda:0 and cpu). This PR modifies the function to ensure that input tensors are moved to the same device as the model, resolving the device mismatch issue.

## Reproduction Step

Using the train_ss.py script to train the protein sorting signal produces the following error:

```RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument mat1 in method wrapper_CUDA_addmm)```


## Solution

The solution involves adding a line of code to move the input tensors (`X_train` and `X_test`) to the same device as the model before performing computations.

